### PR TITLE
Updated scale to a float, allowing smaller images to be upscaled

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,10 +31,10 @@ run the program with the following options (the default zig install directory is
    - `-i, --input <file>`: specify the input image file path (local path/URL) (required)
    - `-o, --output <file>`: specify the output image file (optional, default: `<input>_ascii.jpg`)
    - `-c, --color`: use color ascii characters (optional)
-   - `-s, --scale <int>`: set the downscale factor (optional, default: 1)
+   - `-s, --scale <float>`: set the downscale or upscale factor (optional, default: 1)
    - `-e, --detect_edges`: enable edge detection (optional)
-   - `--sigma1 <int>`: set the sigma1 value for DoG filter (optional, default: 0.3)
-   - `--sigma2 <int>`: set the sigma2 value for DoG filter (optional, default: 1.0)
+   - `--sigma1 <float>`: set the sigma1 value for DoG filter (optional, default: 0.3)
+   - `--sigma2 <float>`: set the sigma2 value for DoG filter (optional, default: 1.0)
    - `-b, --brightness_boost <float>`: increase/decrease perceived brightness (optional, default: 1.0)
 
 2. examples:


### PR DESCRIPTION
The scale is now a float allowing for smaller images to be upscaled, creating larger resolutions as a result. Any scale below 0 auto-reverts to 1.

Also, I updated the readme.md reflecting that scale is now a float, and also changed sigma1 and sigma2 floats as well since they're floats and this was previous not reflected.

Asciigen-wasm is also in progress, so the user can run it in their browser / client-side. Also, the PNG input issues might be because of transparency?? That's why converting it to jpeg fixes it maybe idk.